### PR TITLE
fix(docker): add tzdata to fix "invalid timezone" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apk add --no-cache \
       ca-certificates \
       imagemagick \
       postgresql-client \
+      tzdata \
     && update-ca-certificates
 
 WORKDIR /app


### PR DESCRIPTION
Changing the timezone to anything other than UTC results in an error. Adding the timezone database fixes this.

<img width="467" height="151" alt="image" src="https://github.com/user-attachments/assets/52db9ea0-6016-4d92-9aa0-20f05357cf4c" />
