### PR TITLE
chore(deps): update s6-overlay version to v3.2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN gem install \
 # Final image
 FROM alpine:3.22
 
-ARG S6_OVERLAY_VERSION=3.2.0.2
+ARG S6_OVERLAY_VERSION=3.2.1.0
 ARG TARGETARCH
 
 # Install minimal runtime dependencies including Ruby


### PR DESCRIPTION
Updates s6-overlay to [v3.2.1.0](https://github.com/just-containers/s6-overlay/releases/tag/v3.2.1.0)